### PR TITLE
Change cleanup logging

### DIFF
--- a/shade_janitor/cleanup.py
+++ b/shade_janitor/cleanup.py
@@ -154,7 +154,6 @@ def cleanup_resources(cloud, resource_selection, dry_run=True):
             dry_cleanup_routers(resource_selection['routers'])
         if 'fips' in resource_selection:
             dry_cleanup_floating_ips(resource_selection['fips'])
-        logging.info("Nothing cleaned up!")
     else:
         if 'stacks' in resource_selection:
             cleanup_stacks(cloud, resource_selection['stacks'])

--- a/shade_janitor/janitor.py
+++ b/shade_janitor/janitor.py
@@ -155,3 +155,5 @@ if __name__ == '__main__':
             cleanup_resources(cloud, cleanup, dry_run=False)
 
     Summary.print_summary()
+    if not args.run_cleanup:
+        logging.info("Nothing cleaned up. To cleanup resources, please use --cleanup")


### PR DESCRIPTION
Let user know that nothing cleaned up after printing
summary.

Printing it before summary might confuse some users.

Also, let them know how to actually cleanup the resources.