### PR TITLE
--old: fix NoneType.format() when logging

### DIFF
--- a/shade_janitor/janitor.py
+++ b/shade_janitor/janitor.py
@@ -89,9 +89,10 @@ if __name__ == '__main__':
                 if oldest is None or oldest > rec['created_on']:
                     oldest = rec['created_on']
                     new_search_prefix = rec['name']
-                logging.info('Found Old instance [{}] created on [{}]'
-                             ' age [{}]').format(
-                    rec['name'], rec['created_on'], str(rec['age']))
+                logging.info('Found Old instance [{}] created on [{}] age [{}]'
+                             .format(rec['name'],
+                                     rec['created_on'],
+                                     str(rec['age'])))
 
         if oldest is not None:
             substring = new_search_prefix[0:15]


### PR DESCRIPTION
When using --old, it fails with exception
that None has no .format() method.

It's bcs format is invoked on logging.info() result(!)
while it should be called on it's parameter (the string to be logged).