### PR TITLE
Expose ttl of old servers as CLI opts

### DIFF
--- a/shade_janitor/janitor.py
+++ b/shade_janitor/janitor.py
@@ -39,6 +39,21 @@ def create_parser():
         '--old', dest='old_instances', action='store_true',
         help='attempt to identify old instances')
     parser.add_argument(
+        '--old-active', dest='old_active',
+        default=8, type=int,
+        help=('age (in hours, 0=never) after which ACTIVE servers'
+              ' should be considered as old'))
+    parser.add_argument(
+        '--old-inactive', dest='old_inactive',
+        default=1, type=int,
+        help=('age (in hours, 0=never) after which SHUTOFF servers'
+              ' should be considered as old'))
+    parser.add_argument(
+        '--old-permanent', dest='old_permanent',
+        default=14, type=int,
+        help=('age (in days, 0=never) after which even permanent labeled'
+              ' servers should be considered as old'))
+    parser.add_argument(
         '--cleanup', dest='run_cleanup', action='store_true',
         help='attempt to do cleanup')
     parser.add_argument(
@@ -77,7 +92,11 @@ if __name__ == '__main__':
 
     if args.old_instances:
         age_resources = SelectAgeRelatedResources(cloud)
-        age_resources.select_old_instances()
+        age_resources.select_old_instances(
+            datetime.timedelta(hours=args.old_active),
+            datetime.timedelta(hours=args.old_inactive),
+            datetime.timedelta(days=args.old_permanent)
+        )
         old_resources = age_resources.get_selection()
         new_search_prefix = None
         oldest = None

--- a/shade_janitor/select_age.py
+++ b/shade_janitor/select_age.py
@@ -27,7 +27,8 @@ class SelectAgeRelatedResources(Resources):
 
     def select_old_instances(self, powered_on_ttl=timedelta(hours=8),
                              powered_off_ttl=timedelta(hours=1),
-                             powered_on_permanent_ttl=timedelta(days=14)):
+                             powered_on_permanent_ttl=timedelta(days=14),
+                             now=None):
         """Check for old instances.
 
         Excludes blacklisted instances.
@@ -41,13 +42,15 @@ class SelectAgeRelatedResources(Resources):
                 continue
 
             created_on = dateutil.parser.parse(instance.created)
-            now = datetime.now(pytz.utc)
+            if now is None:
+                now = datetime.now(pytz.utc)
             age = now - created_on
             if self.is_permanent(instance):
-                if age > powered_on_permanent_ttl:
+                if (powered_on_permanent_ttl
+                        and age > powered_on_permanent_ttl):
                     self._add_instance(instance, age=age)
             elif instance['OS-EXT-STS:power_state'] == 0:
-                if age > powered_off_ttl:
+                if (powered_off_ttl and age > powered_off_ttl):
                     self._add_instance(instance, age=age)
-            elif age > powered_on_ttl:
+            elif (powered_on_ttl and age > powered_on_ttl):
                 self._add_instance(instance, age=age)

--- a/shade_janitor/tests/unit/resources/test_age.py
+++ b/shade_janitor/tests/unit/resources/test_age.py
@@ -1,17 +1,103 @@
+import datetime
 import mock
+from pytz import utc
 from shade_janitor.tests.unit import base
 
 from shade_janitor.select_age import SelectAgeRelatedResources
+
+
+class FakeInstance(dict):
+    NOW = datetime.datetime(2000, 1, 10, 0, 0, 1, tzinfo=utc)
+
+    def __init__(self, name, created_ago, power_state=1):
+        super(FakeInstance, self).__init__()
+
+        self.id = name
+        self.name = name
+        # we force to be 1 second before requested time
+        # (due to condition being 'greater-then', but not equal)
+        self.created = str(
+            self.NOW - created_ago - datetime.timedelta(seconds=1)
+        )
+        self['OS-EXT-STS:power_state'] = power_state
 
 
 class TestSelectAge(base.BaseTestCase):
 
     def setUp(self):
         super(TestSelectAge, self).setUp()
+        self.maxDiff = None
+
+        self._td_0 = datetime.timedelta(hours=0)
+        self._td_1h = datetime.timedelta(hours=1)
+        self._td_2h = datetime.timedelta(hours=2)
+        self._td_4h = datetime.timedelta(hours=4)
+        self._td_2d = datetime.timedelta(days=2)
+        self._td_30d = datetime.timedelta(days=30)
+        self._young = {'instances': {
+            '1H_Off': FakeInstance('1H_Off', self._td_1h, 0),
+            '2H_Active': FakeInstance('2H_Active', self._td_2h),
+            'young_permanent': FakeInstance('young_permanent', self._td_1h),
+        }}
+        self._old = {'instances': {
+            '30D_Off': FakeInstance('30D_Off', self._td_30d, 0),
+            '2H_Off': FakeInstance('2H_Off', self._td_2h, 0),
+            '4H_Active': FakeInstance('4H_Active', self._td_4h),
+            'old_permanent': FakeInstance('old_permanent', self._td_2d),
+        }}
+        self._all_as_list = (self._old['instances'].values() +
+                             self._young['instances'].values())
 
     def test_select_age_no_instances(self):
+        """Nothing selected when there are no servers"""
         cloud = mock.Mock()
         cloud.list_servers = mock.Mock(return_value=[])
         resources = SelectAgeRelatedResources(cloud)
         resources.select_old_instances()
+        self.assertEqual({}, resources.get_selection())
+
+    def test_select_age_old(self):
+        """Select older instances"""
+        cloud = mock.Mock()
+        cloud.list_servers = mock.Mock(
+            return_value=self._old['instances'].values())
+
+        resources = SelectAgeRelatedResources(cloud)
+        resources.select_old_instances(powered_off_ttl=self._td_2h,
+                                       powered_on_ttl=self._td_4h,
+                                       powered_on_permanent_ttl=self._td_2d,
+                                       now=FakeInstance.NOW
+                                       )
+
+        self.assertTrue(resources.is_permanent(
+            self._old['instances']['old_permanent']))
+        self.assertEqual(self._old['instances'].keys(),
+                         resources.get_selection()['instances'].keys())
+
+    def test_select_age_no_young(self):
+        """Do not select young(er) instances"""
+        cloud = mock.Mock()
+        cloud.list_servers = mock.Mock(
+            return_value=self._young['instances'].values())
+
+        resources = SelectAgeRelatedResources(cloud)
+        resources.select_old_instances(powered_off_ttl=self._td_2h,
+                                       powered_on_ttl=self._td_4h,
+                                       powered_on_permanent_ttl=self._td_2d,
+                                       now=FakeInstance.NOW
+                                       )
+
+        self.assertTrue(resources.is_permanent(
+            self._young['instances']['young_permanent']))
+        self.assertEqual({}, resources.get_selection())
+
+    def test_select_noage(self):
+        """Zero ttl means do not selected, even when very old"""
+        cloud = mock.Mock()
+        cloud.list_servers = mock.Mock(return_value=self._all_as_list)
+        resources = SelectAgeRelatedResources(cloud)
+        resources.select_old_instances(powered_off_ttl=self._td_0,
+                                       powered_on_ttl=self._td_0,
+                                       powered_on_permanent_ttl=self._td_0
+                                       )
         self.assertEqual({}, resources.get_selection())


### PR DESCRIPTION
This allows to specify time after which
servers should be considered old via command line arguments.

With (for given category) 0 meaning never-consider-old.

Should resolve #27.