### PR TITLE
Add default word to the blacklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ cleanup.
 ### Blacklist
 
 There is a list of words which will keep your resources from being removed.
-The words are: 'slave', 'jenkins' and 'mirror'
+The words are: 'slave', 'jenkins', 'default' and 'mirror'
 
 ### How to add a new type of resource
 

--- a/shade_janitor/resources.py
+++ b/shade_janitor/resources.py
@@ -23,7 +23,7 @@ class Resources(object):
     """
 
     def __init__(self, cloud):
-        self.blacklist = ['jenkins', 'slave', 'mirror']
+        self.blacklist = ['jenkins', 'slave', 'mirror', 'default']
         self._cloud = cloud
         if self._cloud is None:
             raise NoCloudException('No cloud provided')


### PR DESCRIPTION
Latest OpenStack releases include default resources that you can't
and shouldn't remove.